### PR TITLE
More robust setup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,16 +12,16 @@ RUN python3.6 -m pip install --trusted-host pypi.python.org setuptools \
 RUN yum install -y redis
 
 COPY ./docker/dse /usr/local/bin
-RUN chmod +x /usr/local/bin/dse
+RUN chmod 755 /usr/local/bin/dse
 COPY ./docker/autodse /usr/local/bin
-RUN chmod +x /usr/local/bin/autodse
+RUN chmod 755 /usr/local/bin/autodse
 COPY ./docker/checkds /usr/local/bin
-RUN chmod +x /usr/local/bin/checkds
+RUN chmod 755 /usr/local/bin/checkds
 COPY ./docker/ds_generator /usr/local/bin
-RUN chmod +x /usr/local/bin/ds_generator
+RUN chmod 711 /usr/local/bin/ds_generator
 
 COPY ./docker/entrypoint.sh /usr/local/bin
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod 755 /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 
 ADD . /opt/merlin_dse

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,3 +26,6 @@ ENTRYPOINT ["entrypoint.sh"]
 
 ADD . /opt/merlin_dse
 ENV PYTHONPATH /opt/merlin_dse:${PYTHONPATH}
+
+RUN find /opt/merlin_dse/autodse -type d -exec chmod 755 {} \;
+RUN find /opt/merlin_dse/autodse -type f -exec chmod 644 {} \;

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -5,7 +5,7 @@ function git_cmd() {
 }
 
 docker_tag=latest
-
+cwd=$(pwd -P)
 
 print_help() {
   echo "USAGE: $0 [options] cmd";
@@ -180,15 +180,15 @@ add_license FALCONLM_LICENSE_FILE
 add_license XILINXD_LICENSE_FILE
 
 #options="$options -v $script_dir/../license:/opt/merlin/license"
-#options="$options -e LM_LICENSE_FILE=$LM_LICENSE_FILE:/opt/merlin/license/license.lic:$PWD/license.lic"
+#options="$options -e LM_LICENSE_FILE=$LM_LICENSE_FILE:/opt/merlin/license/license.lic:$cwd/license.lic"
 #options="$options -e FALCONLM_LICENSE_FILE=$FALCONLM_LICENSE_FILE"
 #options="$options -e XILINXD_LICENSE_FILE=$XILINXD_LICENSE_FILE"
 options="$options -e MERLIN_AUTO_DEVICE_XILINX=$MERLIN_AUTO_DEVICE_XILINX"
 options="$options -e MERLIN_AUTO_DEVICE_INTEL=$MERLIN_AUTO_DEVICE_INTEL"
 
-base_dir=$(get_base $PWD)
+base_dir=$(get_base $cwd)
 if [ ${illegal_base[$base_dir]+abc} ]; then
-  echo "[merlin-cmd] ERROR: running from $PWD is not supported, please run from a different directory"
+  echo "[merlin-cmd] ERROR: running from $cwd is not supported, please run from a different directory"
   exit 1
 fi
 
@@ -199,7 +199,7 @@ echo " \
 docker run \
     $options \
     -v "$base_dir":"$base_dir" \
-    -w="$PWD" \
+    -w="$cwd" \
     -e "WITH_DOCKER=1" \
     --rm \
     -t \
@@ -209,7 +209,7 @@ docker run \
 docker run \
     $options \
     -v "$base_dir":"$base_dir" \
-    -w="$PWD" \
+    -w="$cwd" \
     -e "WITH_DOCKER=1" \
     --rm \
     -t \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-redis-server &> /dev/null &
+# prevent SIGINT from interrupting redis
+setsid redis-server >/dev/null 2>&1 &
 
 export HOME=/home
 


### PR DESCRIPTION
Addresses some issues for a smoother setup process:

- Account for symlinks in the pwd when determining the mount point.
  - `pwd -P`
- Set proper permissions for stricter umasks.
  - e.g. `chmod 755` for go+rx
- Ignore SIGINT for backgrounded redis-server.
  - `setsid redis-server &`